### PR TITLE
Feature/implement rocket booking actions

### DIFF
--- a/src/components/rockets.jsx
+++ b/src/components/rockets.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getRockets } from '../redux/rockets/rocketsSlice';
+import { reserveRocket, cancelReservation } from '../redux/rockets/rocketsSlice';
 
 const Rockets = () => {
   const dispatch = useDispatch();
@@ -10,6 +11,14 @@ const Rockets = () => {
     dispatch(getRockets());
   }, [dispatch]);
 
+  const handleReserveRocket = (rocketId) => {
+    dispatch(reserveRocket(rocketId));
+  };
+
+  const handleCancelReservation = (rocketId) => {
+    dispatch(cancelReservation(rocketId));
+  };
+
   return (
     <>
       {rockets.map((rocket) => (
@@ -17,6 +26,12 @@ const Rockets = () => {
           <img src={rocket.flickr_images[0]} alt={rocket.name} />
           <p>{rocket.rocket_name}</p>
           <p>{rocket.rocket_type}</p>
+           {/* Render the reservation button or cancel reservation button based on the reserved status */}
+           {rocket.reserved ? (
+              <button onClick={() => handleCancelReservation(rocket.id)}>Cancel Reservation</button>
+            ) : (
+              <button onClick={() => handleReserveRocket(rocket.id)}>Reserve Rocket</button>
+            )}
         </div>
       ))}
     </>

--- a/src/components/rockets.jsx
+++ b/src/components/rockets.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getRockets } from '../redux/rockets/rocketsSlice';
-import { reserveRocket, cancelReservation } from '../redux/rockets/rocketsSlice';
+import { getRockets, reserveRocket, cancelReservation } from '../redux/rockets/rocketsSlice';
 
 const Rockets = () => {
   const dispatch = useDispatch();
@@ -26,12 +25,13 @@ const Rockets = () => {
           <img src={rocket.flickr_images[0]} alt={rocket.name} />
           <p>{rocket.rocket_name}</p>
           <p>{rocket.rocket_type}</p>
-           {/* Render the reservation button or cancel reservation button based on the reserved status */}
-           {rocket.reserved ? (
-              <button onClick={() => handleCancelReservation(rocket.id)}>Cancel Reservation</button>
-            ) : (
-              <button onClick={() => handleReserveRocket(rocket.id)}>Reserve Rocket</button>
-            )}
+          {/* Render the reservation button or cancel reservation button */}
+          {/* based on the reserved status */}
+          {rocket.reserved ? (
+            <button type="button" onClick={() => handleCancelReservation(rocket.id)}>Cancel Reservation</button>
+          ) : (
+            <button type="button" onClick={() => handleReserveRocket(rocket.id)}>Reserve Rocket</button>
+          )}
         </div>
       ))}
     </>

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -25,19 +25,19 @@ const RocketsSlice = createSlice({
     reserveRocket: (state, action) => {
       const rocketId = action.payload;
       const rockets = state.rockets.map((rocket) => (
-        rocket.id === rocketId ? 
-        { ...rocket, reserved: true } : rocket
-        ));
-        state.rockets = rockets;
+        rocket.id === rocketId
+          ? { ...rocket, reserved: true } : rocket
+      ));
+      state.rockets = rockets;
     },
     cancelReservation: (state, action) => {
       const rocketId = action.payload;
-      const rockets =state.rockets.map((rocket) => (
-        rocket.id === rocketId ?
-        { ...rocket, reserved: false } : rocket
+      const rockets = state.rockets.map((rocket) => (
+        rocket.id === rocketId
+          ? { ...rocket, reserved: false } : rocket
       ));
       state.rockets = rockets;
-    }
+    },
   },
   extraReducers(builder) {
     builder
@@ -55,6 +55,6 @@ const RocketsSlice = createSlice({
   },
 });
 
-export const { reserveRocket, cancelReservation } = rocketsSlice.actions;
+export const { reserveRocket, cancelReservation } = RocketsSlice.actions;
 export { getRockets };
 export default RocketsSlice.reducer;

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -21,7 +21,24 @@ const initialState = {
 const RocketsSlice = createSlice({
   name: 'rockets',
   initialState,
-  reducers: {},
+  reducers: {
+    reserveRocket: (state, action) => {
+      const rocketId = action.payload;
+      const rockets = state.rockets.map((rocket) => (
+        rocket.id === rocketId ? 
+        { ...rocket, reserved: true } : rocket
+        ));
+        state.rockets = rockets;
+    },
+    cancelReservation: (state, action) => {
+      const rocketId = action.payload;
+      const rockets =state.rockets.map((rocket) => (
+        rocket.id === rocketId ?
+        { ...rocket, reserved: false } : rocket
+      ));
+      state.rockets = rockets;
+    }
+  },
   extraReducers(builder) {
     builder
       .addCase(getRockets.fulfilled, (state, action) => {
@@ -38,5 +55,6 @@ const RocketsSlice = createSlice({
   },
 });
 
+export const { reserveRocket, cancelReservation } = rocketsSlice.actions;
 export { getRockets };
 export default RocketsSlice.reducer;


### PR DESCRIPTION
# Implemented rocket  booking actions

In this pull request, I implemented the following

- [x] When a user clicks the "Reserve rocket" button, an action is dispatched to update the store. Using the ID of the rocket the state is updated and the rocket is set as reserved. 
- [x] When a user clicks the "Cancel Reservation" button, an action is dispatched to update the store. Using the ID of the reserved rocket the state is updated and its reserved status is set to false.