### PR TITLE
Feature/implement mission leaving actions

### DIFF
--- a/src/components/missions.jsx
+++ b/src/components/missions.jsx
@@ -1,14 +1,37 @@
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import Table from 'react-bootstrap/Table';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import { joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
 const Missions = () => {
+  const dispatch = useDispatch();
   const { missions, isLoading, error } = useSelector((state) => state.missions);
 
   const style = {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+  };
+
+  const nonActive = {
+    border: 'none',
+    borderRadius: '6px',
+    backgroundColor: 'black',
+    color: 'white',
+  };
+  const active = {
+    border: 'none',
+    borderRadius: '6px',
+    backgroundColor: '#008000',
+    color: 'white',
+  };
+
+  const handleJoinMission = (missionId) => {
+    dispatch(joinMission(missionId));
+  };
+
+  const handleLeaveMission = (missionId) => {
+    dispatch(leaveMission(missionId));
   };
 
   if (isLoading) return (<div>Loading...</div>);
@@ -30,8 +53,15 @@ const Missions = () => {
             <tr key={mission.mission_id}>
               <td>{mission.mission_name}</td>
               <td>{mission.description}</td>
-              <td>NOT A MEMBER</td>
-              <td><button type="button" aria-label="Join Mission">Join Misson</button></td>
+              <td>
+                { mission.reserved
+                  ? (<p style={nonActive}>NOT A MEMBER</p>)
+                  : (<p style={active}>Active Member</p>) }
+              </td>
+              <td>
+                { mission.reserved
+                  ? (<button type="button" aria-label="Join Mission" onClick={() => handleJoinMission(mission.mission_id)}>Join Misson</button>) : (<button type="button" aria-label="Leave Mission" onClick={() => handleLeaveMission(mission.mission_id)}>Leave Misson</button>)}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/components/missions.jsx
+++ b/src/components/missions.jsx
@@ -1,6 +1,7 @@
 import { useSelector, useDispatch } from 'react-redux';
 import Table from 'react-bootstrap/Table';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import styles from '../styles/missions.module.css';
 import { joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
 const Missions = () => {
@@ -11,19 +12,6 @@ const Missions = () => {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-  };
-
-  const nonActive = {
-    border: 'none',
-    borderRadius: '6px',
-    backgroundColor: 'black',
-    color: 'white',
-  };
-  const active = {
-    border: 'none',
-    borderRadius: '6px',
-    backgroundColor: '#008000',
-    color: 'white',
   };
 
   const handleJoinMission = (missionId) => {
@@ -55,12 +43,12 @@ const Missions = () => {
               <td>{mission.description}</td>
               <td>
                 { mission.reserved
-                  ? (<p style={nonActive}>NOT A MEMBER</p>)
-                  : (<p style={active}>Active Member</p>) }
+                  ? (<p className={styles.Active}>Active Member</p>)
+                  : (<p className={styles.nonActive}>NOT A MEMBER</p>) }
               </td>
               <td>
                 { mission.reserved
-                  ? (<button type="button" aria-label="Join Mission" onClick={() => handleJoinMission(mission.mission_id)}>Join Misson</button>) : (<button type="button" aria-label="Leave Mission" onClick={() => handleLeaveMission(mission.mission_id)}>Leave Misson</button>)}
+                  ? (<button className={styles.leave} type="button" aria-label="Leave Mission" onClick={() => handleLeaveMission(mission.mission_id)}>Leave Misson</button>) : (<button className={styles.join} type="button" aria-label="Join Mission" onClick={() => handleJoinMission(mission.mission_id)}>Join Misson</button>)}
               </td>
             </tr>
           ))}

--- a/src/components/missions.jsx
+++ b/src/components/missions.jsx
@@ -43,7 +43,7 @@ const Missions = () => {
               <td>{mission.description}</td>
               <td>
                 { mission.reserved
-                  ? (<p className={styles.Active}>Active Member</p>)
+                  ? (<p className={styles.active}>Active Member</p>)
                   : (<p className={styles.nonActive}>NOT A MEMBER</p>) }
               </td>
               <td>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -20,7 +20,22 @@ const fetchMissions = createAsyncThunk('missions/fetchMissions', async (_, { rej
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const missionId = action.payload;
+      const missions = state.missions.map((mission) => (
+        mission.mission_id === missionId
+          ? { ...mission, reserved: true } : mission
+      ));
+      state.missions = missions;
+    },
+    leaveMission: (state, action) => {
+      const missionId = action.payload;
+      const missions = state.missions.map((mission) => (mission.mission_id === missionId
+        ? { ...mission, reserved: false } : mission));
+      state.missions = missions;
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchMissions.pending, (state) => {
@@ -41,5 +56,6 @@ const missionsSlice = createSlice({
   },
 });
 
+export const { joinMission, leaveMission } = missionsSlice.actions;
 export { fetchMissions };
 export default missionsSlice.reducer;

--- a/src/styles/missions.module.css
+++ b/src/styles/missions.module.css
@@ -1,0 +1,34 @@
+.nonActive {
+  border: none;
+  border-radius: 4px;
+  background-color: rgb(95, 95, 95);
+  color: white;
+  font-size: 12px;
+  min-width: max-content;
+  padding: 3px;
+}
+
+.active {
+  border: none;
+  border-radius: 4px;
+  background-color: #009b9d;
+  color: white;
+  font-size: 12px;
+  min-width: max-content;
+  padding: 3px;
+}
+
+.join {
+  background-color: transparent;
+  border: 2px solid rgb(95, 95, 95);
+  border-radius: 4px;
+  min-width: max-content;
+}
+
+.leave {
+  background-color: transparent;
+  border: 2px solid red;
+  color: red;
+  border-radius: 4px;
+  min-width: max-content;
+}

--- a/src/styles/navBar.module.css
+++ b/src/styles/navBar.module.css
@@ -7,8 +7,8 @@
 }
 
 .navBar {
-  border-bottom: 1px solid #e8e8e8;
-  padding: 2%;
+  border-bottom: 2px solid #e8e8e8;
+  padding: 20px;
   margin-bottom: 18px;
 }
 


### PR DESCRIPTION
# Implemented mission leaving and mission join actions

In this pull request, I implemented the following

- [x] When a user clicks the "Join Mission" button, an action is dispatched to update the store using the mission Id and `reserved` is set to `true` in the mission object.  Vice-versa for the "Leave Mission" button
- [x] Missions that the user has joined already show a badge "`Active Member`" instead of the default "NOT A MEMBER" and a button "`Leave Mission`" instead of the "`Join Mission`" button (as per design). This is implemented using the ternary operator as the React conditional rendering syntax

